### PR TITLE
Fix to support device names with unicode characters

### DIFF
--- a/bin/bluez-scanner.py
+++ b/bin/bluez-scanner.py
@@ -20,7 +20,7 @@ def device_found(address, properties):
 			uuids += ("%s " % uuid)
 
         if (name != "undefined" or uuids != ""):
-		print("DeviceFound: Address = %s, Name = %s, RSSI = %d, UUIDs = %s" % (address, name, rssi, uuids.strip()))
+		print("DeviceFound: Address = %s, Name = %s, RSSI = %d, UUIDs = %s" % (address, name.encode("utf-8"), rssi, uuids.strip()))
 
 def property_changed(name, value):
 	if (name == "Powered"):


### PR DESCRIPTION
When a device, such as an iPhone, has a name with unicode characters (e.g. Ana's iPhone), the discovery functionality breaks with the below error. The fix here is to print out the name as utf-8 encoded (as per http://docs.python.org/2/howto/unicode.html#the-unicode-type).

stderr: ERROR:dbus.connection:Exception in handler for D-Bus signal:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/dbus/connection.py", line 230, in maybe_handle_message
    self._handler(_args, *_kwargs)
  File "/root/src/node_modules/noble/lib/linux/../../bin/bluez-scanner.py", line 22, in device_found
    print("DeviceFound: Address = %s, Name = %s, RSSI = %d, UUIDs = %s" % (address, name, rssi, uuids.strip()))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 57: ordinal not in range(128)
