### PR TITLE
Bugfix: scan exits and RangeErrors

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -35,119 +35,118 @@ HciBle.prototype.onStdoutData = function(data) {
 
   var newLineIndex;
   while ((newLineIndex = this._buffer.indexOf('\n')) !== -1) {
-    var line = this._buffer.substring(0, newLineIndex);
-    var found;
-    
-    this._buffer = this._buffer.substring(newLineIndex + 1);
+    try{
+      var line = this._buffer.substring(0, newLineIndex);
+      var found;
 
-    debug('line = ' + line);
+      this._buffer = this._buffer.substring(newLineIndex + 1);
 
-    if ((found = line.match(/^adapterState (.*)$/))) {
-      var adapterState = found[1];
+      debug('line = ' + line);
 
-      debug('adapterState = ' + adapterState);
+      if ((found = line.match(/^adapterState (.*)$/))) {
+        var adapterState = found[1];
 
-      if (adapterState === 'unauthorized') {
-        console.log('noble warning: adapter state unauthorized, please run as root or with sudo');
-      }
-      
-      this.emit('stateChange', adapterState);
-    } else if ((found = line.match(/^event (.*)$/))) {
-      var event = found[1];
-      var splitEvent = event.split(',');
+        debug('adapterState = ' + adapterState);
 
-      var address = splitEvent[0];
-      var addressType = splitEvent[1];
-      var eir = new Buffer(splitEvent[2], 'hex');
-      var rssi = parseInt(splitEvent[3], 10);
-
-      debug('address = ' + address);
-      debug('addressType = ' + addressType);
-      debug('eir = ' + eir.toString('hex'));
-      debug('rssi = ' + rssi);
-
-      var previouslyDiscovered = !!this._discoveries[address];
-      var advertisement =  previouslyDiscovered ? this._discoveries[address].advertisement : {
-        localName: undefined,
-        serviceData: undefined,
-        txPowerLevel: undefined,
-        manufacturerData: undefined,
-        serviceUuids: []
-      };
-
-      var i = 0;
-      var j = 0;
-      var serviceUuid = null;
-
-      while ((i + 1) < eir.length) {
-        var length = eir.readUInt8(i);
-        var type = eir.readUInt8(i + 1); // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
-
-        if ((i + length + 1) > eir.length) {
-          debug('invalid EIR data, out of range of buffer length');
-          break;
+        if (adapterState === 'unauthorized') {
+          console.log('noble warning: adapter state unauthorized, please run as root or with sudo');
         }
 
-        var bytes = eir.slice(i + 2).slice(0, length - 1);
+        this.emit('stateChange', adapterState);
+      } else if ((found = line.match(/^event (.*)$/))) {
+        var event = found[1];
+        var splitEvent = event.split(',');
 
-        switch(type) {
-          case 0x02: // Incomplete List of 16-bit Service Class UUID
-          case 0x03: // Complete List of 16-bit Service Class UUIDs
-            for (j = 0; j < bytes.length; j += 2) {
-              serviceUuid = bytes.readUInt16LE(j).toString(16);
-              if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
-                advertisement.serviceUuids.push(serviceUuid);
+        var address = splitEvent[0];
+        var addressType = splitEvent[1];
+        var eir = new Buffer(splitEvent[2], 'hex');
+        var rssi = parseInt(splitEvent[3], 10);
+
+        debug('address = ' + address);
+        debug('addressType = ' + addressType);
+        debug('eir = ' + eir.toString('hex'));
+        debug('rssi = ' + rssi);
+
+        var previouslyDiscovered = !!this._discoveries[address];
+        var advertisement =  previouslyDiscovered ? this._discoveries[address].advertisement : {
+          localName: undefined,
+          serviceData: undefined,
+          txPowerLevel: undefined,
+          manufacturerData: undefined,
+          serviceUuids: []
+        };
+
+        var i = 0;
+        var j = 0;
+        var serviceUuid = null;
+
+        while (i < eir.length) {
+          var length = eir.readUInt8(i);
+          var type = eir.readUInt8(i + 1); // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
+          var bytes = eir.slice(i + 2).slice(0, length - 1);
+
+          switch(type) {
+            case 0x02: // Incomplete List of 16-bit Service Class UUID
+            case 0x03: // Complete List of 16-bit Service Class UUIDs
+              for (j = 0; j < bytes.length; j += 2) {
+                serviceUuid = bytes.readUInt16LE(j).toString(16);
+                if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
+                  advertisement.serviceUuids.push(serviceUuid);
+                }
               }
-            }
-            break;
+              break;
 
-          case 0x06: // Incomplete List of 128-bit Service Class UUIDs
-          case 0x07: // Complete List of 128-bit Service Class UUIDs
-            for (j = 0; j < bytes.length; j += 16) {
-              serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
-              if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
-                advertisement.serviceUuids.push(serviceUuid);
+            case 0x06: // Incomplete List of 128-bit Service Class UUIDs
+            case 0x07: // Complete List of 128-bit Service Class UUIDs
+              for (j = 0; j < bytes.length; j += 16) {
+                serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+                if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
+                  advertisement.serviceUuids.push(serviceUuid);
+                }
               }
-            }
-            break;
+              break;
 
-          case 0x08: // Shortened Local Name
-          case 0x09: // Complete Local Name»
-            advertisement.localName = bytes.toString('utf8');
-            break;
+            case 0x08: // Shortened Local Name
+            case 0x09: // Complete Local Name»
+              advertisement.localName = bytes.toString('utf8');
+              break;
 
-          case 0x0a: // Tx Power Level
-            advertisement.txPowerLevel = bytes.readInt8(0);
-            break;
+            case 0x0a: // Tx Power Level
+              advertisement.txPowerLevel = bytes.readInt8(0);
+              break;
 
-          case 0x16: // Service Data
-            advertisement.serviceData = bytes;
-            break;
+            case 0x16: // Service Data
+              advertisement.serviceData = bytes;
+              break;
 
-          case 0xff: // Manufacturer Specific Data
-            advertisement.manufacturerData = bytes;
-            break;
+            case 0xff: // Manufacturer Specific Data
+              advertisement.manufacturerData = bytes;
+              break;
+          }
+
+          i += (length + 1);
         }
 
-        i += (length + 1);
+        debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
+
+        var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
+
+        this._discoveries[address] = {
+          address: address,
+          addressType: addressType,
+          advertisement: advertisement,
+          rssi: rssi,
+          count: (discoveryCount + 1)
+        };
+
+        // only report after an even number of events, so more advertisement data can be collected
+        if (this._discoveries[address].count % 2 === 0) {
+          this.emit('discover', address, addressType, advertisement, rssi);
+        }
       }
-
-      debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
-
-      var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
-
-      this._discoveries[address] = {
-        address: address,
-        addressType: addressType,
-        advertisement: advertisement,
-        rssi: rssi,
-        count: (discoveryCount + 1)
-      };
-
-      // only report after an even number of events, so more advertisement data can be collected
-      if (this._discoveries[address].count % 2 === 0) {
-        this.emit('discover', address, addressType, advertisement, rssi);
-      }
+    } catch (e) {
+        debug("error parsing line from buffer");
+        debug(e);
     }
   }
 };
@@ -169,4 +168,5 @@ HciBle.prototype.stopScanning = function() {
 };
 
 module.exports = HciBle;
+
 

--- a/src/hci-ble.c
+++ b/src/hci-ble.c
@@ -121,23 +121,25 @@ int main(int argc, const char* argv[])
       hciEventLen = read(hciSocket, hciEventBuf, sizeof(hciEventBuf));
       leMetaEvent = (evt_le_meta_event *)(hciEventBuf + (1 + HCI_EVENT_HDR_SIZE));
       hciEventLen -= (1 + HCI_EVENT_HDR_SIZE);
+      
+      if (leMetaEvent->subevent == 0x02) {
 
-      if (leMetaEvent->subevent != 0x02) {
-        break;
+        leAdvertisingInfo = (le_advertising_info *)(leMetaEvent->data + 1);
+        ba2str(&leAdvertisingInfo->bdaddr, btAddress);
+
+        printf("event %s,%s,", btAddress, (leAdvertisingInfo->bdaddr_type == LE_PUBLIC_ADDRESS) ? "public" : "random");
+
+        for (i = 0; i < leAdvertisingInfo->length; i++) {
+            printf("%02x", leAdvertisingInfo->data[i]);
+        }
+
+        rssi = *(leAdvertisingInfo->data + leAdvertisingInfo->length);
+
+        printf(",%d\n", rssi);
+  
+      } else {
+        printf("got non-advertising event: %x\n",leMetaEvent->subevent);
       }
-
-      leAdvertisingInfo = (le_advertising_info *)(leMetaEvent->data + 1);
-      ba2str(&leAdvertisingInfo->bdaddr, btAddress);
-
-      printf("event %s,%s,", btAddress, (leAdvertisingInfo->bdaddr_type == LE_PUBLIC_ADDRESS) ? "public" : "random");
-
-      for (i = 0; i < leAdvertisingInfo->length; i++) {
-          printf("%02x", leAdvertisingInfo->data[i]);
-      }
-
-      rssi = *(leAdvertisingInfo->data + leAdvertisingInfo->length);
-
-      printf(",%d\n", rssi);
     }
   }
 


### PR DESCRIPTION
## Problem: Scans would exit at seemingly random times.

Scans were exiting because a subevent was received that was not an advertising packet (e.g. not 0x02). It's not clear where this event comes from and I can't find good documentation on it's value (integer 42). I changed hci-ble.c to simply log any non-advertising events - the original behavior was to break out of the scan loop.

A side effect of this is that scans don't automatically stop when a connection is created. I'm okay with this, as my use case is to frequently connect to devices while continuing to scan for new ones in the background. If this isn't what most people are after, we could call stopScanning from `connect` in bindings.js, or add a keepScanning=false default to the connect function.
## Problem: Corrupt data would cause a RangeError when parsing the buffer

Your buffer length check works well most of the time. However, when the data is corrupted, I still get Range Errors. I  wrapped each line of buffer parsing in a try/catch, so that at least noble won't crash.

I still get strange "pauses" in my scans, usually coinciding with a positive rssi value. Nothing seems to be crashing anymore, though, which is good enough for now.

Also, I'm not sure why the diff below is so messed up - it's much cleaner when you diff these files side-by-side
