### PR TITLE
Support for latest release of Sensor Tag

### DIFF
--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -99,10 +99,6 @@ nobleBindings.stopScanning = function() {
 };
 
 nobleBindings.on('kCBMsgId37', function(args) {
-  if (Object.keys(args.kCBMsgArgAdvertisementData).length === 0) {
-    return;
-  }
-
   var deviceUuid = args.kCBMsgArgDeviceUUID.toString('hex');
   var advertisement = {
     localName: args.kCBMsgArgAdvertisementData.kCBAdvDataLocalName || args.kCBMsgArgName,


### PR DESCRIPTION
My Sensor Tag (delivered today) offers a blank `kCBMsgArgAdvertisementData` field, and so the `'discover'` event is not emitted.
