### PR TITLE
Added support for multiple serviceData fields

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -124,7 +124,7 @@ HciBle.prototype.onStdoutData = function(data) {
 
           case 0x16: // Service Data, there can be multiple occurences
             var serviceDataUuid = bytes.slice(0, 2).toString('hex').match(/.{1,2}/g).reverse().join('');
-            var serviceData = bytes.slice(2,bytes.length-3)
+            var serviceData = bytes.slice(2,bytes.length)
             advertisement.serviceData.push({serviceDataUuid: serviceDataUuid, serviceData: serviceData});
             break;
 


### PR DESCRIPTION
I have changed the way serviceData is stored for the peripheral. I have a ble sensor which broadcasts its data via multiple serviceData fields. The current implementation only showed one field in the advertisement. The new creates an array every time the adv-packet is received. Resetting is important as you cannot replace the changing object in the array, like you do with the service uuids. 
- Those multiple occurences might apply to other fields aswell, but i do not know the standard well enough.
- This is a fix for Linux only, I do not know if this needs to be addressed in the OSX variant aswell.

Please pull to master. Thanks
