### PR TITLE
peripheral-explorer.js: check if data present for characteristic user description

### DIFF
--- a/examples/peripheral-explorer.js
+++ b/examples/peripheral-explorer.js
@@ -100,7 +100,9 @@ function explore(peripheral) {
                         function(userDescriptionDescriptor){
                           if (userDescriptionDescriptor) {
                             userDescriptionDescriptor.readValue(function(error, data) {
-                              characteristicInfo += ' (' + data.toString() + ')';
+                              if (data) {
+                                characteristicInfo += ' (' + data.toString() + ')';
+                              }
                               callback();
                             });
                           } else {


### PR DESCRIPTION
Fixing error when characteristic user description not set.

Found this when scanning a peripheral running one of the example Arduino sketches in https://github.com/sandeepmistry/arduino-BLEPeripheral
