### PR TITLE
Bump the minimum Node requirement to 4.x

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "browser": true,
   "node": true,
   "mocha": true,
+  "esversion": 6,
   "unused": false, //enable after cleanup
   "undef": false, //enable after cleanup
   "globals": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ os:
   - osx
 language: cpp
 env:
-  - NODE_VERSION="0.8"
-  - NODE_VERSION="0.10"
-  - NODE_VERSION="0.12"
   - NODE_VERSION="4"
   - NODE_VERSION="6"
   - NODE_VERSION="8"
+
 matrix:
   fast_finish: true
 before_install:
@@ -18,9 +16,6 @@ before_install:
   - nvm use --delete-prefix $NODE_VERSION;
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CC="g++-4.8";
-    fi
-  - if [ $NODE_VERSION == "0.8" ]; then
-      npm install -g npm@2;
     fi
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "main": "./index.js",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=4.0"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
4.x is now supported across all major distros and their LTS versions (if they have one)