### PR TITLE
Support for ES6 Promises

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "browser": true,
+  "esversion": 6,
   "node": true,
   "mocha": true,
   "unused": false, //enable after cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ os:
   - osx
 language: cpp
 env:
-  - NODE_VERSION="0.8"
-  - NODE_VERSION="0.10"
-  - NODE_VERSION="0.12"
   - NODE_VERSION="4.0"
   - NODE_VERSION="4.1"
   - NODE_VERSION="4.2"

--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -35,8 +35,8 @@ Characteristic.prototype.toString = function() {
 };
 
 Characteristic.prototype.read = function(callback) {
-  if (callback) {
-    var onRead = function(data, isNotificaton) {
+  const promise = new Promise((resolve, reject) => {
+    const onRead = function(data, isNotificaton) {
       // only call the callback if 'read' event and non-notification
       // 'read' for non-notifications is only present for backwards compatbility
       if (!isNotificaton) {
@@ -44,93 +44,113 @@ Characteristic.prototype.read = function(callback) {
         this.removeListener('read', onRead);
 
         // call the callback
-        callback(null, data);
+        resolve(data);
       }
     }.bind(this);
 
     this.on('read', onRead);
+
+    this._noble.read(
+      this._peripheralId,
+      this._serviceUuid,
+      this.uuid
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.read(
-    this._peripheralId,
-    this._serviceUuid,
-    this.uuid
-  );
+  return promise;
 };
 
 Characteristic.prototype.write = function(data, withoutResponse, callback) {
-  if (process.title !== 'browser') {
-    if (!(data instanceof Buffer)) {
-      throw new Error('data must be a Buffer');
-    }
+  if (process.title !== 'browser' && !(data instanceof Buffer)) {
+    throw new Error('data must be a Buffer');
   }
 
-  if (callback) {
-    this.once('write', function() {
-      callback(null);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('write', resolve);
+
+    this._noble.write(
+      this._peripheralId,
+      this._serviceUuid,
+      this.uuid,
+      data,
+      withoutResponse
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.write(
-    this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
-    data,
-    withoutResponse
-  );
+  return promise;
 };
 
 Characteristic.prototype.broadcast = function(broadcast, callback) {
-  if (callback) {
-    this.once('broadcast', function() {
-      callback(null);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('broadcast', resolve);
+
+    this._noble.broadcast(
+      this._peripheralId,
+      this._serviceUuid,
+      this.uuid,
+      broadcast
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.broadcast(
-    this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
-    broadcast
-  );
+  return promise;
 };
 
 // deprecated in favour of subscribe/unsubscribe
 Characteristic.prototype.notify = function(notify, callback) {
-  if (callback) {
-    this.once('notify', function() {
-      callback(null);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('notify', resolve);
+
+    this._noble.notify(
+      this._peripheralId,
+      this._serviceUuid,
+      this.uuid,
+      notify
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.notify(
-    this._peripheralId,
-    this._serviceUuid,
-    this.uuid,
-    notify
-  );
+  return promise;
 };
 
 Characteristic.prototype.subscribe = function(callback) {
-  this.notify(true, callback);
+  return this.notify(true, callback);
 };
 
 Characteristic.prototype.unsubscribe = function(callback) {
-  this.notify(false, callback);
+  return this.notify(false, callback);
 };
 
 Characteristic.prototype.discoverDescriptors = function(callback) {
-  if (callback) {
-    this.once('descriptorsDiscover', function(descriptors) {
-      callback(null, descriptors);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('descriptorsDiscover', resolve);
+
+    this._noble.discoverDescriptors(
+      this._peripheralId,
+      this._serviceUuid,
+      this.uuid
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.discoverDescriptors(
-    this._peripheralId,
-    this._serviceUuid,
-    this.uuid
-  );
+  return promise;
 };
 
 module.exports = Characteristic;

--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -33,17 +33,22 @@ Descriptor.prototype.toString = function() {
 };
 
 Descriptor.prototype.readValue = function(callback) {
-  if (callback) {
-    this.once('valueRead', function(data) {
-      callback(null, data);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('valueRead', resolve);
+
+    this._noble.readValue(
+      this._peripheralId,
+      this._serviceUuid,
+      this._characteristicUuid,
+      this.uuid
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
-  this._noble.readValue(
-    this._peripheralId,
-    this._serviceUuid,
-    this._characteristicUuid,
-    this.uuid
-  );
+
+  return promise;
 };
 
 Descriptor.prototype.writeValue = function(data, callback) {
@@ -51,18 +56,23 @@ Descriptor.prototype.writeValue = function(data, callback) {
     throw new Error('data must be a Buffer');
   }
 
-  if (callback) {
-    this.once('valueWrite', function() {
-      callback(null);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('valueWrite', resolve);
+
+    this._noble.writeValue(
+      this._peripheralId,
+      this._serviceUuid,
+      this._characteristicUuid,
+      this.uuid,
+      data
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
-  this._noble.writeValue(
-    this._peripheralId,
-    this._serviceUuid,
-    this._characteristicUuid,
-    this.uuid,
-    data
-  );
+
+  return promise;
 };
 
 module.exports = Descriptor;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -88,37 +88,37 @@ Noble.prototype.onAddressChange = function(address) {
 };
 
 Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback) {
-  var scan = function(state) {
-    if (state !== 'poweredOn') {
-      var error = new Error('Could not start scanning, state is ' + state + ' (not poweredOn)');
+  const promise = new Promise((resolve, reject) => {
+    const scan = function(state) {
+      if (state !== 'poweredOn') {
+        const error = new Error('Could not start scanning, state is ' + state + ' (not poweredOn)');
 
-      if (typeof callback === 'function') {
-        callback(error);
+        reject(error);
       } else {
-        throw error;
+        this.once('scanStart', resolve);
+
+        this._discoveredPeripheralUUids = [];
+        this._allowDuplicates = allowDuplicates;
+
+        this._bindings.startScanning(serviceUuids, allowDuplicates);
       }
+    };
+
+    //if bindings still not init, do it now
+    if (!this.initialized) {
+      this._bindings.init();
+      this.initialized = true;
+      this.once('stateChange', scan.bind(this));
     } else {
-      if (callback) {
-        this.once('scanStart', function(filterDuplicates) {
-          callback(null, filterDuplicates);
-        });
-      }
-
-      this._discoveredPeripheralUUids = [];
-      this._allowDuplicates = allowDuplicates;
-
-      this._bindings.startScanning(serviceUuids, allowDuplicates);
+      scan.call(this, this._state);
     }
-  };
+  });
 
-  //if bindings still not init, do it now
-  if (!this.initialized) {
-    this._bindings.init();
-    this.initialized = true;
-    this.once('stateChange', scan.bind(this));
-  }else{
-    scan.call(this, this._state);
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
+
+  return promise;
 };
 
 Noble.prototype.onScanStart = function(filterDuplicates) {
@@ -127,12 +127,19 @@ Noble.prototype.onScanStart = function(filterDuplicates) {
 };
 
 Noble.prototype.stopScanning = function(callback) {
-  if (callback) {
-    this.once('scanStop', callback);
+  const promise = new Promise((resolve, reject) => {
+    this.once('scanStop', resolve);
+
+    if(this._bindings && this.initialized){
+      this._bindings.stopScanning();
+    }
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
-  if(this._bindings && this.initialized){
-    this._bindings.stopScanning();
-  }
+
+  return promise;
 };
 
 Noble.prototype.onScanStop = function() {

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -135,8 +135,11 @@ Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUu
   });
 
   if (callback && typeof callback == 'function') {
-    promise.then(({services, characteristics}) =>
-      callback(null, services, characteristics), callback);
+    promise.then((result) => {
+      const services = result.services;
+      const characteristics = result.characteristics;
+      callback(null, services, characteristics);
+    }, callback);
   }
 
   return promise;

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -33,91 +33,132 @@ Peripheral.prototype.toString = function() {
 };
 
 Peripheral.prototype.connect = function(callback) {
-  if (callback) {
+  const promise = new Promise((resolve, reject) => {
     this.once('connect', function(error) {
-      callback(error);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
     });
+
+    if (this.state === 'connected') {
+      this.emit('connect', new Error('Peripheral already connected'));
+    } else {
+      this.state = 'connecting';
+      this._noble.connect(this.id);
+    }
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  if (this.state === 'connected') {
-    this.emit('connect', new Error('Peripheral already connected'));
-  } else {
-    this.state = 'connecting';
-    this._noble.connect(this.id);
-  }
+  return promise;
 };
 
 Peripheral.prototype.disconnect = function(callback) {
-  if (callback) {
+  const promise = new Promise((resolve, reject) => {
     this.once('disconnect', function() {
-      callback(null);
+      resolve();
     });
+
+    this.state = 'disconnecting';
+    this._noble.disconnect(this.id);
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
-  this.state = 'disconnecting';
-  this._noble.disconnect(this.id);
+
+  return promise;
 };
 
 Peripheral.prototype.updateRssi = function(callback) {
-  if (callback) {
+  const promise = new Promise((resolve, reject) => {
     this.once('rssiUpdate', function(rssi) {
-      callback(null, rssi);
+      resolve(rssi);
     });
+
+    this._noble.updateRssi(this.id);
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.updateRssi(this.id);
+  return promise;
 };
 
 Peripheral.prototype.discoverServices = function(uuids, callback) {
-  if (callback) {
+  const promise = new Promise((resolve, reject) => {
     this.once('servicesDiscover', function(services) {
-      callback(null, services);
+      resolve(services);
     });
+
+    this._noble.discoverServices(this.id, uuids);
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.discoverServices(this.id, uuids);
+  return promise;
 };
 
 Peripheral.prototype.discoverSomeServicesAndCharacteristics = function(serviceUuids, characteristicsUuids, callback) {
-  this.discoverServices(serviceUuids, function(err, services) {
-    var numDiscovered = 0;
-    var allCharacteristics = [];
+  const promise = new Promise((resolve, reject) => {
+    this.discoverServices(serviceUuids, function(err, services) {
+      var numDiscovered = 0;
+      var allCharacteristics = [];
 
-    for (var i in services) {
-      var service = services[i];
+      for (var i in services) {
+        var service = services[i];
 
-      service.discoverCharacteristics(characteristicsUuids, function(error, characteristics) {
-        numDiscovered++;
+        service.discoverCharacteristics(characteristicsUuids, function(error, characteristics) {
+          numDiscovered++;
 
-        if (error === null) {
-          for (var j in characteristics) {
-            var characteristic = characteristics[j];
+          if (error === null) {
+            for (var j in characteristics) {
+              var characteristic = characteristics[j];
 
-            allCharacteristics.push(characteristic);
+              allCharacteristics.push(characteristic);
+            }
           }
-        }
 
-        if (numDiscovered === services.length) {
-          if (callback) {
-            callback(null, services, allCharacteristics);
+          if (numDiscovered === services.length) {
+            resolve({services, characteristics: allCharacteristics});
           }
-        }
-      }.bind(this));
-    }
-  }.bind(this));
+        }.bind(this));
+      }
+    }.bind(this));
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(({services, characteristics}) =>
+      callback(null, services, characteristics), callback);
+  }
+
+  return promise;
 };
 
 Peripheral.prototype.discoverAllServicesAndCharacteristics = function(callback) {
-  this.discoverSomeServicesAndCharacteristics([], [], callback);
+  return this.discoverSomeServicesAndCharacteristics([], [], callback);
 };
 
 Peripheral.prototype.readHandle = function(handle, callback) {
-  if (callback) {
+  const promise = new Promise((resolve, reject) => {
     this.once('handleRead' + handle, function(data) {
-      callback(null, data);
+      resolve(data);
     });
+    this._noble.readHandle(this.id, handle);
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.readHandle(this.id, handle);
+  return promise;
 };
 
 Peripheral.prototype.writeHandle = function(handle, data, withoutResponse, callback) {
@@ -125,13 +166,17 @@ Peripheral.prototype.writeHandle = function(handle, data, withoutResponse, callb
     throw new Error('data must be a Buffer');
   }
 
-  if (callback) {
-    this.once('handleWrite' + handle, function() {
-      callback(null);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('handleWrite' + handle, resolve);
+
+    this._noble.writeHandle(this.id, handle, data, withoutResponse);
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.writeHandle(this.id, handle, data, withoutResponse);
+  return promise;
 };
 
 module.exports = Peripheral;

--- a/lib/service.js
+++ b/lib/service.js
@@ -34,31 +34,39 @@ Service.prototype.toString = function() {
 };
 
 Service.prototype.discoverIncludedServices = function(serviceUuids, callback) {
-  if (callback) {
-    this.once('includedServicesDiscover', function(includedServiceUuids) {
-      callback(null, includedServiceUuids);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('includedServicesDiscover', resolve);
+
+    this._noble.discoverIncludedServices(
+      this._peripheralId,
+      this.uuid,
+      serviceUuids
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.discoverIncludedServices(
-    this._peripheralId,
-    this.uuid,
-    serviceUuids
-  );
+  return promise;
 };
 
 Service.prototype.discoverCharacteristics = function(characteristicUuids, callback) {
-  if (callback) {
-    this.once('characteristicsDiscover', function(characteristics) {
-      callback(null, characteristics);
-    });
+  const promise = new Promise((resolve, reject) => {
+    this.once('characteristicsDiscover', resolve);
+
+    this._noble.discoverCharacteristics(
+      this._peripheralId,
+      this.uuid,
+      characteristicUuids
+    );
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  this._noble.discoverCharacteristics(
-    this._peripheralId,
-    this.uuid,
-    characteristicUuids
-  );
+  return promise;
 };
 
 module.exports = Service;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "./index.js",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=4.0"
   },
   "os": [
     "darwin",

--- a/test/test-characteristic.js
+++ b/test/test-characteristic.js
@@ -71,6 +71,16 @@ describe('Characteristic', function() {
       });
       characteristic.emit('read', mockData);
     });
+
+    it('should return a promise', function(done) {
+      var mockData = new Buffer(0);
+      const p = characteristic.read().then((data) => {
+        data.should.equal(mockData);
+        done();
+      });
+
+      characteristic.emit('read', mockData);
+    });
   });
 
   describe('write', function() {
@@ -106,6 +116,11 @@ describe('Characteristic', function() {
       });
       characteristic.emit('write');
     });
+
+    it('should return a promise', function(done) {
+      const p = characteristic.write(mockData, true).then(() => done());
+      characteristic.emit('write');
+    });
   });
 
   describe('broadcast', function() {
@@ -125,6 +140,11 @@ describe('Characteristic', function() {
       characteristic.broadcast(true, function() {
         done();
       });
+      characteristic.emit('broadcast');
+    });
+
+    it('should return a promise', function(done) {
+      const p = characteristic.broadcast(true).then(() => done());
       characteristic.emit('broadcast');
     });
   });
@@ -148,6 +168,11 @@ describe('Characteristic', function() {
       });
       characteristic.emit('notify');
     });
+
+    it('should return a promise', function(done) {
+      characteristic.notify(true).then(() => done());
+      characteristic.emit('notify');
+    });
   });
 
   describe('subscribe', function() {
@@ -158,10 +183,14 @@ describe('Characteristic', function() {
     });
 
     it('should callback', function(done) {
-
       characteristic.subscribe(function() {
         done();
       });
+      characteristic.emit('notify');
+    });
+
+    it('should return a promise', function(done) {
+      characteristic.subscribe().then(() => done());
       characteristic.emit('notify');
     });
   });
@@ -177,6 +206,11 @@ describe('Characteristic', function() {
       characteristic.unsubscribe(function() {
         done();
       });
+      characteristic.emit('notify');
+    });
+
+    it('should return a promise', function(done) {
+      characteristic.unsubscribe().then(() => done());
       characteristic.emit('notify');
     });
   });
@@ -198,6 +232,15 @@ describe('Characteristic', function() {
     it('should callback with descriptors', function(done) {
       var mockDescriptors = [];
       characteristic.discoverDescriptors(function(error, descriptors) {
+        descriptors.should.equal(mockDescriptors);
+        done();
+      });
+      characteristic.emit('descriptorsDiscover', mockDescriptors);
+    });
+
+    it('should return a promise', function(done) {
+      var mockDescriptors = [];
+      characteristic.discoverDescriptors().then(function(descriptors) {
         descriptors.should.equal(mockDescriptors);
         done();
       });

--- a/test/test-characteristic.js
+++ b/test/test-characteristic.js
@@ -56,27 +56,20 @@ describe('Characteristic', function() {
       mockNoble.read.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.read(function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('read');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with data', function() {
+    it('should callback with data', function(done) {
       var mockData = new Buffer(0);
-      var callbackData = null;
-
       characteristic.read(function(error, data) {
-        callbackData = data;
+        data.should.equal(mockData);
+        done();
       });
       characteristic.emit('read', mockData);
-
-      callbackData.should.equal(mockData);
     });
   });
 
@@ -107,15 +100,11 @@ describe('Characteristic', function() {
       mockNoble.write.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, mockData, true).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.write(mockData, true, function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('write');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -132,15 +121,11 @@ describe('Characteristic', function() {
       mockNoble.broadcast.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.broadcast(true, function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('broadcast');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -157,15 +142,11 @@ describe('Characteristic', function() {
       mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.notify(true, function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('notify');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -176,15 +157,12 @@ describe('Characteristic', function() {
       mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, true).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
+    it('should callback', function(done) {
 
       characteristic.subscribe(function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('notify');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -195,15 +173,11 @@ describe('Characteristic', function() {
       mockNoble.notify.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid, false).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.unsubscribe(function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('notify');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -214,27 +188,20 @@ describe('Characteristic', function() {
       mockNoble.discoverDescriptors.calledWithExactly(mockPeripheralId, mockServiceUuid, mockUuid).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       characteristic.discoverDescriptors(function() {
-        calledback = true;
+        done();
       });
       characteristic.emit('descriptorsDiscover');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with descriptors', function() {
+    it('should callback with descriptors', function(done) {
       var mockDescriptors = [];
-      var callbackDescriptors = null;
-
       characteristic.discoverDescriptors(function(error, descriptors) {
-        callbackDescriptors = descriptors;
+        descriptors.should.equal(mockDescriptors);
+        done();
       });
       characteristic.emit('descriptorsDiscover', mockDescriptors);
-
-      callbackDescriptors.should.equal(mockDescriptors);
     });
   });
 });

--- a/test/test-descriptor.js
+++ b/test/test-descriptor.js
@@ -82,6 +82,17 @@ describe('Descriptor', function() {
       });
       descriptor.emit('valueRead', mockData);
     });
+
+    it('should return a promise', function(done) {
+      var mockData = new Buffer(0);
+
+      descriptor.readValue().then(function(data) {
+        data.should.equal(mockData);
+
+        done();
+      });
+      descriptor.emit('valueRead', mockData);
+    });
   });
 
   describe('writeValue', function() {
@@ -125,6 +136,13 @@ describe('Descriptor', function() {
         calledback.should.equal(1);
         done();
       }, 100);
+    });
+
+    it('should return a promise', function(done) {
+      descriptor.writeValue(mockData).then(function() {
+        done();
+      });
+      descriptor.emit('valueWrite');
     });
   });
 });

--- a/test/test-descriptor.js
+++ b/test/test-descriptor.js
@@ -49,39 +49,38 @@ describe('Descriptor', function() {
       mockNoble.readValue.calledWithExactly(mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, mockUuid).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       descriptor.readValue(function() {
-        calledback = true;
+        done();
       });
       descriptor.emit('valueRead');
-
-      calledback.should.equal(true);
     });
 
-    it('should not call callback twice', function() {
+    it('should not call callback twice', function(done) {
       var calledback = 0;
 
       descriptor.readValue(function() {
         calledback += 1;
+
       });
       descriptor.emit('valueRead');
       descriptor.emit('valueRead');
 
-      calledback.should.equal(1);
+      setTimeout(() => {
+        calledback.should.equal(1);
+        done();
+      }, 100);
     });
 
-    it('should callback with error, data', function() {
+    it('should callback with error, data', function(done) {
       var mockData = new Buffer(0);
-      var callbackData = null;
 
       descriptor.readValue(function(error, data) {
-        callbackData = data;
+        data.should.equal(mockData);
+
+        done();
       });
       descriptor.emit('valueRead', mockData);
-
-      callbackData.should.equal(mockData);
     });
   });
 
@@ -106,18 +105,14 @@ describe('Descriptor', function() {
       mockNoble.writeValue.calledWithExactly(mockPeripheralId, mockServiceUuid, mockCharacteristicUuid, mockUuid, mockData).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       descriptor.writeValue(mockData, function() {
-        calledback = true;
+        done();
       });
       descriptor.emit('valueWrite');
-
-      calledback.should.equal(true);
     });
 
-    it('should not call callback twice', function() {
+    it('should not call callback twice', function(done) {
       var calledback = 0;
 
       descriptor.writeValue(mockData, function() {
@@ -126,8 +121,10 @@ describe('Descriptor', function() {
       descriptor.emit('valueWrite');
       descriptor.emit('valueWrite');
 
-      calledback.should.equal(1);
+      setTimeout(() => {
+        calledback.should.equal(1);
+        done();
+      }, 100);
     });
-
   });
 });

--- a/test/test-peripheral.js
+++ b/test/test-peripheral.js
@@ -251,7 +251,10 @@ describe('Peripheral', function() {
     });
 
     it('should return a promise', function(done) {
-      peripheral.discoverSomeServicesAndCharacteristics(mockServiceUuids, mockCharacteristicUuids).then(function({services, characteristics}) {
+      peripheral.discoverSomeServicesAndCharacteristics(mockServiceUuids, mockCharacteristicUuids)
+      .then(function(args) {
+        const services = args.services;
+        const characteristics = args.characteristics;
         services.should.equal(mockServices);
         characteristics.should.eql([mockCharacteristic1, mockCharacteristic2, mockCharacteristic3]);
         done();

--- a/test/test-peripheral.js
+++ b/test/test-peripheral.js
@@ -70,15 +70,11 @@ describe('Peripheral', function() {
       mockNoble.connect.calledWithExactly(mockId).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.connect(function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('connect');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -89,15 +85,11 @@ describe('Peripheral', function() {
       mockNoble.disconnect.calledWithExactly(mockId).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.disconnect(function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('disconnect');
-
-      calledback.should.equal(true);
     });
   });
 
@@ -108,26 +100,19 @@ describe('Peripheral', function() {
       mockNoble.updateRssi.calledWithExactly(mockId).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.updateRssi(function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('rssiUpdate');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with rssi', function() {
-      var calledbackRssi = null;
-
+    it('should callback with rssi', function(done) {
       peripheral.updateRssi(function(error, rssi) {
-        calledbackRssi = rssi;
+        rssi.should.equal(mockRssi);
+        done();
       });
       peripheral.emit('rssiUpdate', mockRssi);
-
-      calledbackRssi.should.equal(mockRssi);
     });
   });
 
@@ -146,27 +131,21 @@ describe('Peripheral', function() {
       mockNoble.discoverServices.calledWithExactly(mockId, mockServiceUuids).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.discoverServices(null, function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('servicesDiscover');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with services', function() {
+    it('should callback with services', function(done) {
       var mockServices = [];
-      var calledbackServices = null;
 
       peripheral.discoverServices(null, function(error, services) {
-        calledbackServices = services;
+        services.should.equal(mockServices);
+        done();
       });
       peripheral.emit('servicesDiscover', mockServices);
-
-      calledbackServices.should.equal(mockServices);
     });
   });
 
@@ -207,12 +186,9 @@ describe('Peripheral', function() {
       mockServices[1].discoverCharacteristics.calledWith(mockCharacteristicUuids).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
-
+    it('should callback', function(done) {
       peripheral.discoverSomeServicesAndCharacteristics(mockServiceUuids, mockCharacteristicUuids, function() {
-        calledback = true;
+        done();
       });
 
       var discoverServicesCallback = peripheral.discoverServices.getCall(0).args[1];
@@ -221,17 +197,13 @@ describe('Peripheral', function() {
 
       mockServices[0].discoverCharacteristics.getCall(0).args[1](null, []);
       mockServices[1].discoverCharacteristics.getCall(0).args[1](null, []);
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with the services and characteristics discovered', function() {
-      var calledbackServices = null;
-      var calledbackCharacteristics = null;
-
+    it('should callback with the services and characteristics discovered', function(done) {
       peripheral.discoverSomeServicesAndCharacteristics(mockServiceUuids, mockCharacteristicUuids, function(err, services, characteristics) {
-        calledbackServices = services;
-        calledbackCharacteristics = characteristics;
+        services.should.equal(mockServices);
+        characteristics.should.eql([mockCharacteristic1, mockCharacteristic2, mockCharacteristic3]);
+        done();
       });
 
       var discoverServicesCallback = peripheral.discoverServices.getCall(0).args[1];
@@ -244,9 +216,6 @@ describe('Peripheral', function() {
 
       mockServices[0].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic1]);
       mockServices[1].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic2, mockCharacteristic3]);
-
-      calledbackServices.should.equal(mockServices);
-      calledbackCharacteristics.should.eql([mockCharacteristic1, mockCharacteristic2, mockCharacteristic3]);
     });
   });
 
@@ -269,26 +238,19 @@ describe('Peripheral', function() {
       mockNoble.readHandle.calledWithExactly(mockId, mockHandle).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.readHandle(mockHandle, function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('handleRead' + mockHandle);
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with data', function() {
-      var calledbackData = null;
-
+    it('should callback with data', function(done) {
       peripheral.readHandle(mockHandle, function(error, data) {
-        calledbackData = data;
+        data.should.equal(mockData);
+        done();
       });
       peripheral.emit('handleRead' + mockHandle, mockData);
-
-      calledbackData.should.equal(mockData);
     });
   });
 
@@ -317,15 +279,11 @@ describe('Peripheral', function() {
       mockNoble.writeHandle.calledWithExactly(mockId, mockHandle, mockData, true).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       peripheral.writeHandle(mockHandle, mockData, false, function() {
-        calledback = true;
+        done();
       });
       peripheral.emit('handleWrite' + mockHandle);
-
-      calledback.should.equal(true);
     });
   });
 });

--- a/test/test-peripheral.js
+++ b/test/test-peripheral.js
@@ -76,6 +76,13 @@ describe('Peripheral', function() {
       });
       peripheral.emit('connect');
     });
+
+    it('should return a promise', function(done) {
+      peripheral.connect().then(function() {
+        done();
+      });
+      peripheral.emit('connect');
+    });
   });
 
   describe('disconnect', function() {
@@ -87,6 +94,13 @@ describe('Peripheral', function() {
 
     it('should callback', function(done) {
       peripheral.disconnect(function() {
+        done();
+      });
+      peripheral.emit('disconnect');
+    });
+
+    it('should return a promise', function(done) {
+      peripheral.disconnect().then(function() {
         done();
       });
       peripheral.emit('disconnect');
@@ -109,6 +123,14 @@ describe('Peripheral', function() {
 
     it('should callback with rssi', function(done) {
       peripheral.updateRssi(function(error, rssi) {
+        rssi.should.equal(mockRssi);
+        done();
+      });
+      peripheral.emit('rssiUpdate', mockRssi);
+    });
+
+    it('should return a promise', function(done) {
+      peripheral.updateRssi().then(function(rssi) {
         rssi.should.equal(mockRssi);
         done();
       });
@@ -142,6 +164,16 @@ describe('Peripheral', function() {
       var mockServices = [];
 
       peripheral.discoverServices(null, function(error, services) {
+        services.should.equal(mockServices);
+        done();
+      });
+      peripheral.emit('servicesDiscover', mockServices);
+    });
+
+    it('should return a promise', function(done) {
+      var mockServices = [];
+
+      peripheral.discoverServices(null).then(function(services) {
         services.should.equal(mockServices);
         done();
       });
@@ -217,6 +249,25 @@ describe('Peripheral', function() {
       mockServices[0].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic1]);
       mockServices[1].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic2, mockCharacteristic3]);
     });
+
+    it('should return a promise', function(done) {
+      peripheral.discoverSomeServicesAndCharacteristics(mockServiceUuids, mockCharacteristicUuids).then(function({services, characteristics}) {
+        services.should.equal(mockServices);
+        characteristics.should.eql([mockCharacteristic1, mockCharacteristic2, mockCharacteristic3]);
+        done();
+      });
+
+      var discoverServicesCallback = peripheral.discoverServices.getCall(0).args[1];
+
+      discoverServicesCallback(null, mockServices);
+
+      var mockCharacteristic1 = { uuid: '1' };
+      var mockCharacteristic2 = { uuid: '2' };
+      var mockCharacteristic3 = { uuid: '3' };
+
+      mockServices[0].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic1]);
+      mockServices[1].discoverCharacteristics.getCall(0).args[1](null, [mockCharacteristic2, mockCharacteristic3]);
+    });
   });
 
   describe('discoverAllServicesAndCharacteristics', function() {
@@ -252,6 +303,14 @@ describe('Peripheral', function() {
       });
       peripheral.emit('handleRead' + mockHandle, mockData);
     });
+
+    it('should return a promise', function(done) {
+      peripheral.readHandle(mockHandle).then(function(data) {
+        data.should.equal(mockData);
+        done();
+      });
+      peripheral.emit('handleRead' + mockHandle, mockData);
+    });
   });
 
   describe('writeHandle', function() {
@@ -281,6 +340,13 @@ describe('Peripheral', function() {
 
     it('should callback', function(done) {
       peripheral.writeHandle(mockHandle, mockData, false, function() {
+        done();
+      });
+      peripheral.emit('handleWrite' + mockHandle);
+    });
+
+    it('should return a promise', function(done) {
+      peripheral.writeHandle(mockHandle, mockData, false).then(function() {
         done();
       });
       peripheral.emit('handleWrite' + mockHandle);

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -63,8 +63,17 @@ describe('service', function() {
     });
 
     it('should callback with data', function(done) {
-      var mockIncludedServiceUuids = [];
+      const mockIncludedServiceUuids = [];
       service.discoverIncludedServices(null, function(error, includedServiceUuids) {
+        includedServiceUuids.should.equal(mockIncludedServiceUuids);
+        done();
+      });
+      service.emit('includedServicesDiscover', mockIncludedServiceUuids);
+    });
+
+    it('should return a promise', function(done) {
+      const mockIncludedServiceUuids = [];
+      service.discoverIncludedServices(null).then(function(includedServiceUuids) {
         includedServiceUuids.should.equal(mockIncludedServiceUuids);
         done();
       });
@@ -80,7 +89,7 @@ describe('service', function() {
     });
 
     it('should delegate to noble, with uuids', function() {
-      var mockUuids = [];
+      const mockUuids = [];
 
       service.discoverCharacteristics(mockUuids);
 
@@ -95,9 +104,19 @@ describe('service', function() {
     });
 
     it('should callback with data', function(done) {
-      var mockCharacteristics = [];
+      const mockCharacteristics = [];
 
       service.discoverCharacteristics(null, function(error, mockCharacteristics) {
+        mockCharacteristics.should.equal(mockCharacteristics);
+        done();
+      });
+      service.emit('characteristicsDiscover', mockCharacteristics);
+    });
+
+    it('should return a promise', function(done) {
+      const mockCharacteristics = [];
+
+      service.discoverCharacteristics(null).then(function(mockCharacteristics) {
         mockCharacteristics.should.equal(mockCharacteristics);
         done();
       });

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -55,27 +55,20 @@ describe('service', function() {
       mockNoble.discoverIncludedServices.calledWithExactly(mockPeripheralId, mockUuid, mockUuids).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       service.discoverIncludedServices(null, function() {
-        calledback = true;
+        done();
       });
       service.emit('includedServicesDiscover');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with data', function() {
+    it('should callback with data', function(done) {
       var mockIncludedServiceUuids = [];
-      var callbackIncludedServiceUuids = null;
-
       service.discoverIncludedServices(null, function(error, includedServiceUuids) {
-        callbackIncludedServiceUuids = includedServiceUuids;
+        includedServiceUuids.should.equal(mockIncludedServiceUuids);
+        done();
       });
       service.emit('includedServicesDiscover', mockIncludedServiceUuids);
-
-      callbackIncludedServiceUuids.should.equal(mockIncludedServiceUuids);
     });
   });
 
@@ -94,27 +87,21 @@ describe('service', function() {
       mockNoble.discoverCharacteristics.calledWithExactly(mockPeripheralId, mockUuid, mockUuids).should.equal(true);
     });
 
-    it('should callback', function() {
-      var calledback = false;
-
+    it('should callback', function(done) {
       service.discoverCharacteristics(null, function() {
-        calledback = true;
+        done();
       });
       service.emit('characteristicsDiscover');
-
-      calledback.should.equal(true);
     });
 
-    it('should callback with data', function() {
+    it('should callback with data', function(done) {
       var mockCharacteristics = [];
-      var callbackCharacteristics = null;
 
       service.discoverCharacteristics(null, function(error, mockCharacteristics) {
-        callbackCharacteristics = mockCharacteristics;
+        mockCharacteristics.should.equal(mockCharacteristics);
+        done();
       });
       service.emit('characteristicsDiscover', mockCharacteristics);
-
-      callbackCharacteristics.should.equal(mockCharacteristics);
     });
   });
 });


### PR DESCRIPTION
In this pull request all user-facing APIs that take callbacks now also return promises. This change is backwards compatible. 

Some tests had to be changed, as previously there were expectations that callbacks were called immediately in the same event loop cycle. This is no longer true as callbacks are scheduled with promises, but shouldn't break any user code, which should have been written with an expectation that callbacks are asynchronous in the first place.

Additional tests were added to verify that all promises resolve successfully.

This fork is also published as https://www.npmjs.com/package/noble-promise in the meantime, as I see that main repository had no merging activity for some time. I still hope that this PR will be merged eventually.

@sandeepmistry could you please have a look at this PR? Thanks a lot for the library and I look forward to your feedback.