### PR TITLE
Fix multiple init of bindings

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -51,9 +51,10 @@ function Noble(bindings) {
   //lazy init bindings on first new listener, should be on stateChange
   this.on('newListener', function(event) {
     if (event === 'stateChange' && !this.initialized) {
+      this.initialized = true;
+
       process.nextTick(function() {
         this._bindings.init();
-        this.initialized = true;
       }.bind(this));
     }
   }.bind(this));
@@ -63,8 +64,9 @@ function Noble(bindings) {
     state: {
       get: function () {
         if (!this.initialized) {
-          this._bindings.init();
           this.initialized = true;
+
+          this._bindings.init();
         }
         return this._state;
       }
@@ -115,8 +117,10 @@ Noble.prototype.startScanning = function(serviceUuids, allowDuplicates, callback
 
   //if bindings still not init, do it now
   if (!this.initialized) {
-    this._bindings.init();
     this.initialized = true;
+
+    this._bindings.init();
+
     this.once('stateChange', scan.bind(this));
   }else{
     scan.call(this, this._state);
@@ -132,7 +136,7 @@ Noble.prototype.stopScanning = function(callback) {
   if (callback) {
     this.once('scanStop', callback);
   }
-  if(this._bindings && this.initialized){
+  if (this._bindings && this.initialized) {
     this._bindings.stopScanning();
   }
 };


### PR DESCRIPTION
By setting the initialized flag to true before calling init.

Fixes #765.