### PR TITLE
Increase scan interval and window to 100 ms

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -264,8 +264,8 @@ Hci.prototype.setScanParameters = function() {
 
   // data
   cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
-  cmd.writeUInt16LE(0x0010, 5); // internal, ms * 1.6
-  cmd.writeUInt16LE(0x0010, 7); // window, ms * 1.6
+  cmd.writeUInt16LE(0x00A0, 5); // scan interval, in units of 0.625 ms
+  cmd.writeUInt16LE(0x00A0, 7); // scan window, in units of 0.625 ms
   cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
   cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
 


### PR DESCRIPTION
Scan interval defines the frequency that the scanner hops between advertising channels. Periodically switching has the advantage of avoiding possible interference on those channels.

However, in practice scanning hardware (like a BLE dongle) have blind regions when switching channels where they cannot receive packets. According to [a recent paper](https://pdfs.semanticscholar.org/7cc4/ec16353c9191e9c7e65bb3d80aa4df204ff6.pdf), these blind regions can be as long as milliseconds (depending on hardware and configurations). So, increasing the time between scanner frequency hops should result in an increased advertisement reception rate.

Adjusting the scan interval and window to 100 ms is an arbitrary choice. It felt sufficiently high, without lingering on a channel for too long.

This pull request was tested by running `examples/advertisement-discovery.js` for several seconds to check that BLE advertisements are still being discovered.
