### PR TITLE
Fix: update old services if start/end handle changes

### DIFF
--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -329,6 +329,15 @@ nobleBindings.on('kCBMsgId72', function(args) {
 
       if (!this._peripherals[deviceUuid].services[service.uuid] ) {
         this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
+      } else {
+        const oldService = this._peripherals[deviceUuid].services[service.uuid];
+        if (oldService.startHandle !== service.startHandle) {
+          this._peripherals[deviceUuid].services[service.startHandle] = oldService;
+          oldService.startHandle = service.startHandle;
+        }
+        if (oldService.endHandle !== service.endHandle) {
+          oldService.endHandle = service.endHandle;
+        }
       }
 
       serviceUuids.push(service.uuid);

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -329,7 +329,16 @@ nobleBindings.on('kCBMsgId56', function(args) {
 
       if (typeof this._peripherals[deviceUuid].services[service.uuid] == 'undefined') {
         this._peripherals[deviceUuid].services[service.uuid] = this._peripherals[deviceUuid].services[service.startHandle] = service;
-      }  
+      } else {
+        const oldService = this._peripherals[deviceUuid].services[service.uuid];
+        if (oldService.startHandle !== service.startHandle) {
+          this._peripherals[deviceUuid].services[service.startHandle] = oldService;
+          oldService.startHandle = service.startHandle;
+        }
+        if (oldService.endHandle !== service.endHandle) {
+          oldService.endHandle = service.endHandle;
+        }
+      }
 
       serviceUuids.push(service.uuid);
     }


### PR DESCRIPTION
mac-bindings: #747 remembers previously discovered services, but it does not update the old services when the `startHandle`/`endHandle` changes. `startHandle` and `endHandle` may change after a device firmware update has been performed.       

This fix updates the old services with the values of the new service.

Tested on Sierra (`yosemite.js`) and High Sierra (`highsierra.js`)