### PR TITLE
Lowercasization of the Bluetooth Address

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -637,7 +637,7 @@ Hci.prototype.processLeAdvertisingReport = function(count, data) {
   for (var i = 0; i < count; i++) {
     var type = data.readUInt8(0);
     var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':').toLowerCase();
     var eirLength = data.readUInt8(8);
     var eir = data.slice(9, eirLength + 9);
     var rssi = data.readInt8(eirLength + 9);


### PR DESCRIPTION
Hi, here is the pull request to force the bluetooth mac address sent back by  the bluetooth processLeAdvertisingReport scan function to be in lower case.
( see https://github.com/noble/noble-device/pull/30 )