### PR TITLE
fix npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "async": "~0.2.9",
+    "jshint": "latest",
     "mocha": "^5.2.0",
     "should": "~1.2.2",
     "sinon": "~1.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "win32"
   ],
   "dependencies": {
-    "debug": "~2.2.0"
+    "debug": "^3.1.0"
   },
   "optionalDependencies": {
     "bluetooth-hci-socket": "^0.5.1",
@@ -41,12 +41,11 @@
     "xpc-connection": "~0.1.4"
   },
   "devDependencies": {
-    "jshint": "latest",
-    "mocha": "~1.8.2",
+    "async": "~0.2.9",
+    "mocha": "^5.2.0",
     "should": "~1.2.2",
     "sinon": "~1.6.0",
-    "async": "~0.2.9",
-    "ws": "~0.4.31"
+    "ws": "^5.2.0"
   },
   "scripts": {
     "pretest": "jshint *.js lib/. test/.",


### PR DESCRIPTION
Note that there is still a low severity vulnerability from jshint > lodash https://nodesecurity.io/advisories/577 jshint has fixed this, so it will be available in a future release jshint/jshint@e0b4e91