### PR TITLE
Fixes GATT bug when calling characteristic.subscribe() that caused RangeError exception

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -622,7 +622,12 @@ Gatt.prototype.notify = function(serviceUuid, characteristicUuid, notify) {
     if (opcode === ATT_OP_READ_BY_TYPE_RESP) {
       var type = data[1];
       var handle = data.readUInt16LE(2);
-      var value = data.readUInt16LE(4);
+      var value = 0;
+
+      //Type 02 does not have enough data for this call
+      if (type != 02) {
+        value = data.readUInt16LE(4);
+      }
 
       var useNotify = characteristic.properties & 0x10;
       var useIndicate = characteristic.properties & 0x20;


### PR DESCRIPTION
Before, the GATT code expected that messages from a ble device for `subscribe()` would be long enough to read 4 bytes from. However, I ran into a problem where when a message was type 2 from my device, it did not have enough data to read from and thus the program would crash with a `RangeError` exception . I admittedly do not entirely understand what the types are supposed to represent, especially as the `type` variable is not used elsewhere in the code block. Either way, this change fixes the problem I encountered. 