### PR TITLE
publish current rssi value for link statistics

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -106,6 +106,8 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
     solicitationServiceUuids: []
   };
 
+  advertisement.rssi = rssi;
+
   var discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
   var hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
 


### PR DESCRIPTION
We like to monitor rssi values of advertisements for quality, positioning et. al. 
This allows direct access to the latest rssi value via the advertisement object. 
 