### PR TITLE
OSX fix custom service 128 bit UUID to 16 bit

### DIFF
--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -322,8 +322,9 @@ nobleBindings.on('kCBMsgId72', function(args) {
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
       var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4)
-        serviceUuid = serviceUuid.slice(4, 8)
+      if(serviceUuid.length > 4) {
+        serviceUuid = serviceUuid.slice(4, 8);
+      }
 
       var service = {
         uuid: serviceUuid,
@@ -388,8 +389,9 @@ nobleBindings.on('kCBMsgId76', function(args) {
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
     var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4)
-      serviceUuid = serviceUuid.slice(4, 8)
+    if(serviceUuid.length > 4) {
+      serviceUuid = serviceUuid.slice(4, 8);
+    }
       
     var includedService = {
       uuid: serviceUuid,

--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -321,8 +321,12 @@ nobleBindings.on('kCBMsgId72', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(serviceUuid.length > 4)
+        serviceUuid = serviceUuid.slice(4, 8)
+
       var service = {
-        uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+        uuid: serviceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -383,8 +387,12 @@ nobleBindings.on('kCBMsgId76', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(serviceUuid.length > 4)
+      serviceUuid = serviceUuid.slice(4, 8)
+      
     var includedService = {
-      uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+      uuid: serviceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -321,13 +321,13 @@ nobleBindings.on('kCBMsgId72', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4) {
-        serviceUuid = serviceUuid.slice(4, 8);
+      var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(discoveredServiceUuid.length > 4) {
+        discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
       }
 
       var service = {
-        uuid: serviceUuid,
+        uuid: discoveredServiceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -388,13 +388,13 @@ nobleBindings.on('kCBMsgId76', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4) {
-      serviceUuid = serviceUuid.slice(4, 8);
+    var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(discoveredServiceUuid.length > 4) {
+      discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
     }
       
     var includedService = {
-      uuid: serviceUuid,
+      uuid: discoveredServiceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -234,9 +234,10 @@ nobleBindings.on('kCBMsgId55', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-      let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4)
-        serviceUuid = serviceUuid.slice(4, 8)
+      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(serviceUuid.length > 4) {
+        serviceUuid = serviceUuid.slice(4, 8);
+      }
 
       var service = {
         uuid: serviceUuid,
@@ -282,9 +283,10 @@ nobleBindings.on('kCBMsgId62', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-    let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4)
-      serviceUuid = serviceUuid.slice(4, 8)
+    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(serviceUuid.length > 4) {
+      serviceUuid = serviceUuid.slice(4, 8);
+    }
 
     var includedService = {
       uuid: serviceUuid,

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -234,8 +234,12 @@ nobleBindings.on('kCBMsgId55', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+      let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(serviceUuid.length > 4)
+        serviceUuid = serviceUuid.slice(4, 8)
+
       var service = {
-        uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+        uuid: serviceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -278,8 +282,12 @@ nobleBindings.on('kCBMsgId62', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+    let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(serviceUuid.length > 4)
+      serviceUuid = serviceUuid.slice(4, 8)
+
     var includedService = {
-      uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+      uuid: serviceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -234,13 +234,13 @@ nobleBindings.on('kCBMsgId55', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4) {
-        serviceUuid = serviceUuid.slice(4, 8);
+      var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(discoveredServiceUuid.length > 4) {
+        discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
       }
 
       var service = {
-        uuid: serviceUuid,
+        uuid: discoveredServiceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -283,13 +283,13 @@ nobleBindings.on('kCBMsgId62', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4) {
-      serviceUuid = serviceUuid.slice(4, 8);
+    var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(discoveredServiceUuid.length > 4) {
+      discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
     }
 
     var includedService = {
-      uuid: serviceUuid,
+      uuid: discoveredServiceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -321,8 +321,12 @@ nobleBindings.on('kCBMsgId56', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+      let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(serviceUuid.length > 4)
+        serviceUuid = serviceUuid.slice(4, 8)
+
       var service = {
-        uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+        uuid: serviceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -383,8 +387,12 @@ nobleBindings.on('kCBMsgId63', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
+    let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(serviceUuid.length > 4)
+      serviceUuid = serviceUuid.slice(4, 8)
+
     var includedService = {
-      uuid: args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex'),
+      uuid: serviceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -321,13 +321,13 @@ nobleBindings.on('kCBMsgId56', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4) {
-        serviceUuid = serviceUuid.slice(4, 8);
+      var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(discoveredServiceUuid.length > 4) {
+        discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
       }
 
       var service = {
-        uuid: serviceUuid,
+        uuid: discoveredServiceUuid,
         startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
         endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
       };
@@ -388,13 +388,13 @@ nobleBindings.on('kCBMsgId63', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4) {
-      serviceUuid = serviceUuid.slice(4, 8);
+    var discoveredServiceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(discoveredServiceUuid.length > 4) {
+      discoveredServiceUuid = discoveredServiceUuid.slice(4, 8);
     }
 
     var includedService = {
-      uuid: serviceUuid,
+      uuid: discoveredServiceUuid,
       startHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceStartHandle,
       endHandle: args.kCBMsgArgServices[i].kCBMsgArgServiceEndHandle
     };

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -321,9 +321,10 @@ nobleBindings.on('kCBMsgId56', function(args) {
 
   if (args.kCBMsgArgServices) {
     for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-      let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-      if(serviceUuid.length > 4)
-        serviceUuid = serviceUuid.slice(4, 8)
+      var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+      if(serviceUuid.length > 4) {
+        serviceUuid = serviceUuid.slice(4, 8);
+      }
 
       var service = {
         uuid: serviceUuid,
@@ -387,9 +388,10 @@ nobleBindings.on('kCBMsgId63', function(args) {
     this._peripherals[deviceUuid].services[serviceStartHandle].includedServices || {};
 
   for(var i = 0; i < args.kCBMsgArgServices.length; i++) {
-    let serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
-    if(serviceUuid.length > 4)
-      serviceUuid = serviceUuid.slice(4, 8)
+    var serviceUuid = args.kCBMsgArgServices[i].kCBMsgArgUUID.toString('hex');
+    if(serviceUuid.length > 4) {
+      serviceUuid = serviceUuid.slice(4, 8);
+    }
 
     var includedService = {
       uuid: serviceUuid,


### PR DESCRIPTION
So  currently OSX when it doesn't understand service UUID, such as FIDO custom uuid is fffd, it returns full 128 bit UUID(0000fffd00001000800000805f9b34fb). However on windows it always returns 16bit UUID i.e fffd

This change fixes OSX bindings to ensure that for any service, 16bit UUID is always returned.
