### PR TITLE
Android npm install enabled

### DIFF
--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -9,7 +9,7 @@ module.exports = function() {
     return require('./distributed/bindings');
   } else if (platform === 'darwin') {
     return require('./mac/bindings');
-  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32') {
+  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32' || platform === 'android' ) {
     return require('./hci-socket/bindings');
   } else {
     throw new Error('Unsupported platform');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "darwin",
     "linux",
     "freebsd",
-    "win32"
+    "win32",
+    "android"
   ],
   "dependencies": {
     "debug": "~2.2.0"


### PR DESCRIPTION
Pull request from katonage/noble
In termux, installation was fine afterwards, also dependent module like 
npm install node-poweredup
was installed ok ( module for Bluetooth communication with Lego powdered up toys)
To install bluetooth-hci-socket
I installed first:
pkg i python2
npm i gcc
npm i make
npm install -g node-gyp
npm i bluetooth-hci-socket
Than it made the compilation in termux.

Still, functionality was not tested afterwards: I'm not sure how to do it.
