### PR TITLE
Call init and clean listeners when device goes to power on after power off

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -3,7 +3,7 @@ var debug = require('debug')('hci');
 var events = require('events');
 var util = require('util');
 
-var BluetoothHciSocket = require('bluetooth-hci-socket');
+var BluetoothHciSocket = require('@abandonware/bluetooth-hci-socket');
 
 var HCI_COMMAND_PKT = 0x01;
 var HCI_ACLDATA_PKT = 0x02;
@@ -270,8 +270,8 @@ Hci.prototype.setScanParameters = function() {
 
   // data
   cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
-  cmd.writeUInt16LE(0x0010, 5); // internal, ms * 1.6
-  cmd.writeUInt16LE(0x0010, 7); // window, ms * 1.6
+  cmd.writeUInt16LE(0x03C0, 5); // internal, ms * 1.6
+  cmd.writeUInt16LE(0x03C0, 7); // window, ms * 1.6
   cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
   cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
 
@@ -308,8 +308,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
   cmd.writeUInt8(0x19, 3);
 
   // data
-  cmd.writeUInt16LE(0x0060, 4); // interval
-  cmd.writeUInt16LE(0x0030, 6); // window
+  cmd.writeUInt16LE(0x0100, 4); // interval
+  cmd.writeUInt16LE(0x00A0, 6); // window
   cmd.writeUInt8(0x00, 8); // initiator filter
 
   cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 9); // peer address type
@@ -317,8 +317,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
 
   cmd.writeUInt8(0x00, 16); // own address type
 
-  cmd.writeUInt16LE(0x0006, 17); // min interval
-  cmd.writeUInt16LE(0x000c, 19); // max interval
+  cmd.writeUInt16LE(0x000c, 17); // min interval
+  cmd.writeUInt16LE(0x0018, 19); // max interval
   cmd.writeUInt16LE(0x0000, 21); // latency
   cmd.writeUInt16LE(0x00c8, 23); // supervision timeout
   cmd.writeUInt16LE(0x0004, 25); // min ce length
@@ -640,23 +640,27 @@ Hci.prototype.processLeConnComplete = function(status, data) {
 };
 
 Hci.prototype.processLeAdvertisingReport = function(count, data) {
-  for (var i = 0; i < count; i++) {
-    var type = data.readUInt8(0);
-    var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
-    var eirLength = data.readUInt8(8);
-    var eir = data.slice(9, eirLength + 9);
-    var rssi = data.readInt8(eirLength + 9);
+  try {
+    for (var i = 0; i < count; i++) {
+      var type = data.readUInt8(0);
+      var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
+      var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+      var eirLength = data.readUInt8(8);
+      var eir = data.slice(9, eirLength + 9);
+      var rssi = data.readInt8(eirLength + 9);
 
-    debug('\t\t\ttype = ' + type);
-    debug('\t\t\taddress = ' + address);
-    debug('\t\t\taddress type = ' + addressType);
-    debug('\t\t\teir = ' + eir.toString('hex'));
-    debug('\t\t\trssi = ' + rssi);
+      debug('\t\t\ttype = ' + type);
+      debug('\t\t\taddress = ' + address);
+      debug('\t\t\taddress type = ' + addressType);
+      debug('\t\t\teir = ' + eir.toString('hex'));
+      debug('\t\t\trssi = ' + rssi);
 
-    this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
+      this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
 
-    data = data.slice(eirLength + 10);
+      data = data.slice(eirLength + 10);
+    }
+  } catch (e) {
+    debug('CAUGHT EXCEPTION - ILLEGAL PACKET ' + e);
   }
 };
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -110,6 +110,12 @@ Hci.prototype.pollIsDevUp = function() {
 
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
+      if (this._state === 'poweredOff') {
+        this._socket.removeAllListeners();
+        this._state = null;
+        this.init();
+        return;
+      }
       this.setSocketFilter();
       this.setEventMask();
       this.setLeEventMask();


### PR DESCRIPTION
This small change allows noble to start over when for some reason the device goes to off.
Without it the old instanced objects are used which are not valid anymore.