### PR TITLE
open up reset API for application

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ __NOTE:__ ```noble.state``` must be ```poweredOn``` before scanning is started. 
 noble.stopScanning();
 ```
 
+#### Reset device
+
+```javascript
+noble.reset();
+```
+
+As there is no return event for reset, you may want to put sleep for a fraction of a second.
+
 #### Peripheral
 
 ##### Connect
@@ -141,6 +149,8 @@ noble.stopScanning();
 ```javascript
 peripheral.connect([callback(error)]);
 ```
+
+Some of the bluetooth devices doesn't connect seamlessly, may be because of bluetooth device firmware or kernel. Do reset the device with noble.reset() API before connect API.
 
 ##### Disconnect or cancel pending connection
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -59,6 +59,10 @@ NobleBindings.prototype.disconnect = function(peripheralUuid) {
   this._hci.disconnect(this._handles[peripheralUuid]);
 };
 
+NobleBindings.prototype.reset = function() {
+  this._hci.reset();
+};
+
 NobleBindings.prototype.updateRssi = function(peripheralUuid) {
   this._hci.readRssi(this._handles[peripheralUuid]);
 };

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -146,6 +146,10 @@ Noble.prototype.onScanStop = function() {
   this.emit('scanStop');
 };
 
+Noble.prototype.reset = function() {
+  this._bindings.reset();
+};
+
 Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, advertisement, rssi) {
   var peripheral = this._peripherals[uuid];
 


### PR DESCRIPTION
Resetting device before connect solves the issue #864 .

The device I am using is having Broadcom serial bluetooth module. After debugging the issue, I could find, there might not be a problem from noble connection command. But this could be the issue at module firmware. As "Command Disallowed" error actually comes from the module firmware to the kernel to userspace and so to noble via hci socket. I did verify this issue by hcitool also. And before connect, we can do reset the bluetooth device to overcome this issue. This is a workaround, and I feel that actual fix should be in Bluetooth device firmware. But, we can't expect everyone will have very updated bluetooth firmware as well as the latest kernel.

So to have reset command available to the application gives a wide set of noble users an option to overcome with this kind of issues.