### PR TITLE
allow connection to all `connectable` peripherals

### DIFF
--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -39,8 +39,8 @@ Peripheral.prototype.connect = function(callback) {
     });
   }
 
-  if (this.state === 'connected') {
-    this.emit('connect', new Error('Peripheral already connected'));
+  if (!this.state.connectable) {
+    this.emit('connect', new Error('Peripheral not connectable'));
   } else {
     this.state = 'connecting';
     this._noble.connect(this.id);


### PR DESCRIPTION
Allow connection to any peripheral where `peripheral.connectable` is `true`.

`peripheral.state` can become out of sync with `peripheral.connectable` in cases where there is no disconnect event.

This happens when plugging / unplugging an external bluetooth adapter on MacOS while a peripheral is connected as described here: https://github.com/noble/noble/issues/881