### PR TITLE
use xpc-connect

### DIFF
--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -4,7 +4,7 @@ var util          = require('util');
 
 var debug         = require('debug')('highsierra-bindings');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var localAddress  = require('./local-address');
 var uuidToAddress = require('./uuid-to-address');

--- a/lib/mac/legacy.js
+++ b/lib/mac/legacy.js
@@ -10,7 +10,7 @@ var isLessThan10_8_5 = (parseFloat(osRelease) < 12.5);
 var localAddress  = require('./local-address');
 var uuidToAddress = require('./uuid-to-address');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var NobleBindings = function() {
   this._peripherals = {};

--- a/lib/mac/mavericks.js
+++ b/lib/mac/mavericks.js
@@ -4,7 +4,7 @@ var util = require('util');
 
 var debug = require('debug')('mavericks-bindings');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var localAddress  = require('./local-address');
 var uuidToAddress = require('./uuid-to-address');

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -4,7 +4,7 @@ var util          = require('util');
 
 var debug         = require('debug')('yosemite-bindings');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var localAddress  = require('./local-address');
 var uuidToAddress = require('./uuid-to-address');

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "optionalDependencies": {
     "bluetooth-hci-socket": "^0.5.1",
     "bplist-parser": "0.0.6",
-    "xpc-connection": "~0.1.4"
+    "xpc-connect": "^1.1.2"
   },
   "devDependencies": {
     "jshint": "latest",


### PR DESCRIPTION
[xpc-connection](https://www.npmjs.com/package/xpc-connection) does not appear to be maintained anymore. Might I suggest you give [xpc-connect](https://www.npmjs.com/package/xpc-connect) a try which is a fork with added support for Mojave