### PR TITLE
Patch Error Ws

### DIFF
--- a/lib/websocket/bindings.js
+++ b/lib/websocket/bindings.js
@@ -2,7 +2,7 @@ var events = require('events');
 var util = require('util');
 
 var debug = require('debug')('bindings');
-var WebSocket = require('ws');
+var WebSocket = window.require('ws');
 
 var NobleBindings = function() {
   var port = 0xB1e;


### PR DESCRIPTION
To avoid bugs when implementing websocket with the use of overlay like quasar

to ```node_modules/noble/lib/websocket/bindings.js```
change ```var WebSocket = require('ws');``` -> ```var WebSocket = window.require('ws');```