### PR TITLE
This location must be true when using noble-mac on mojyave or later OS

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -170,7 +170,7 @@ Noble.prototype.onDiscover = function(uuid, address, addressType, connectable, a
 
   var previouslyDiscoverd = (this._discoveredPeripheralUUids.indexOf(uuid) !== -1);
 
-  if (!previouslyDiscoverd) {
+  if (previouslyDiscoverd) {
     this._discoveredPeripheralUUids.push(uuid);
   }
 


### PR DESCRIPTION
When using noble-mac, localName could be obtained by applying the modified part